### PR TITLE
refactor: remove debug logs

### DIFF
--- a/starkyx/src/chip/builder/mod.rs
+++ b/starkyx/src/chip/builder/mod.rs
@@ -401,8 +401,6 @@ pub(crate) mod tests {
         // x1' <- x0 + x1
         builder.set_to_expression_transition(&x_1.next(), x_0.expr() + x_1.expr());
 
-        builder.watch(&x_1, "x_1 fib");
-
         let num_rows = 1 << 10;
         let public_inputs = [
             F::ZERO,

--- a/starkyx/src/machine/stark/mod.rs
+++ b/starkyx/src/machine/stark/mod.rs
@@ -424,7 +424,6 @@ mod tests {
 
         let a = builder.alloc::<FieldRegister<Fp25519>>();
         let b = builder.alloc::<FieldRegister<Fp25519>>();
-        let c = builder.add(a, b);
 
         let num_rows = 1 << 16;
         let stark = builder.build::<C, 2>(num_rows);

--- a/starkyx/src/machine/stark/mod.rs
+++ b/starkyx/src/machine/stark/mod.rs
@@ -425,7 +425,6 @@ mod tests {
         let a = builder.alloc::<FieldRegister<Fp25519>>();
         let b = builder.alloc::<FieldRegister<Fp25519>>();
         let c = builder.add(a, b);
-        builder.watch(&c, "c");
 
         let num_rows = 1 << 16;
         let stark = builder.build::<C, 2>(num_rows);


### PR DESCRIPTION
Debug logs are currently unnecessarily being outputted. The watch statements make the debugging process for `blobstreamx` and `vectorx` difficult.