### PR TITLE
chore: curve25519-dalek, plonky2, clippy

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,7 +24,7 @@ jobs:
   #       uses: actions-rs/toolchain@v1
   #       with:
   #         profile: minimal
-  #         toolchain: nightly-2024-01-25
+  #         toolchain: nightly-2024-02-22
   #         override: true
 
   #     - name: rust-cache
@@ -61,7 +61,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2024-01-25
+          toolchain: nightly-2024-02-22
           override: true
           components: rustfmt, clippy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,8 +783,8 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "plonky2"
-version = "0.1.4"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd#d2598bded0cb24d36b0a9900e8ffd104c470831b"
+version = "0.2.0"
+source = "git+https://github.com/mir-protocol/plonky2.git#62ffe11a984dbc0e6fe92d812fa8da78b7ba73c7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -795,12 +795,11 @@ dependencies = [
  "log",
  "num",
  "plonky2_field",
- "plonky2_maybe_rayon 0.1.1 (git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd)",
+ "plonky2_maybe_rayon 0.2.0",
  "plonky2_util",
  "rand",
  "rand_chacha",
  "serde",
- "serde_json",
  "static_assertions",
  "unroll",
  "web-time",
@@ -808,8 +807,8 @@ dependencies = [
 
 [[package]]
 name = "plonky2_field"
-version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd#d2598bded0cb24d36b0a9900e8ffd104c470831b"
+version = "0.2.0"
+source = "git+https://github.com/mir-protocol/plonky2.git#62ffe11a984dbc0e6fe92d812fa8da78b7ba73c7"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -832,16 +831,16 @@ dependencies = [
 
 [[package]]
 name = "plonky2_maybe_rayon"
-version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd#d2598bded0cb24d36b0a9900e8ffd104c470831b"
+version = "0.2.0"
+source = "git+https://github.com/mir-protocol/plonky2.git#62ffe11a984dbc0e6fe92d812fa8da78b7ba73c7"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "plonky2_util"
-version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=d2598bd#d2598bded0cb24d36b0a9900e8ffd104c470831b"
+version = "0.2.0"
+source = "git+https://github.com/mir-protocol/plonky2.git#62ffe11a984dbc0e6fe92d812fa8da78b7ba73c7"
 
 [[package]]
 name = "plotters"
@@ -1151,7 +1150,7 @@ dependencies = [
  "log",
  "num",
  "plonky2",
- "plonky2_maybe_rayon 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plonky2_maybe_rayon 0.1.1",
  "pprof",
  "rand",
  "seq-macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,12 +137,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
 
 [[package]]
 name = "cfg-if"
@@ -305,9 +302,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.0"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622178105f911d937a42cdb140730ba4a3ed2becd8ae6ce39c7d28b5d75d4588"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -113,9 +113,9 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bumpalo"
-version = "3.15.1"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c764d619ca78fccbf3069b37bd7af92577f044bb15236036662d79b6559f25b7"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "bytemuck"
@@ -137,9 +137,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 
 [[package]]
 name = "cfg-if"
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "const-random"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
  "const-random-macro",
 ]
@@ -324,7 +324,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -425,9 +425,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "half"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -504,7 +504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
  "ahash",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "is-terminal",
  "itoa",
  "log",
@@ -521,7 +521,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys",
 ]
@@ -552,9 +552,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1111,7 +1111,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1222,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1233,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1275,7 +1275,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1339,9 +1339,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -1355,9 +1355,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1365,24 +1365,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1390,28 +1390,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1419,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1464,7 +1464,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1484,17 +1484,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -1505,9 +1505,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1517,9 +1517,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1529,9 +1529,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1541,9 +1541,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1553,9 +1553,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1565,9 +1565,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1577,9 +1577,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "zerocopy"
@@ -1598,7 +1598,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-01-25"
+channel = "nightly-2024-02-22"
 components = ["llvm-tools", "rustc-dev"]

--- a/starkyx/Cargo.toml
+++ b/starkyx/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 hex = "0.4.3"
 subtle-encoding = "0.5.1"
 bincode = "1.3.3"
-curve25519-dalek = "4.1.0"
+curve25519-dalek = "4"
 env_logger = "0.9.0"
 
 [dev-dependencies]

--- a/starkyx/Cargo.toml
+++ b/starkyx/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = { version = "1.0.40", default-features = false }
 itertools = { version = "0.10.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
 plonky2_maybe_rayon = { version = "0.1.0", default-features = false }
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "d2598bd", default-features = false, optional = true }
+plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", version = "0.2.0", default-features = false, optional = true }
 num = { version = "0.4", default-features = false }
 rand = "0.8.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -27,7 +27,7 @@ curve25519-dalek = "4"
 env_logger = "0.9.0"
 
 [dev-dependencies]
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "d2598bd", features = [
+plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", version = "0.2.0", features = [
     "gate_testing",
 ] }
 env_logger = { version = "0.9.0", default-features = false }

--- a/starkyx/Cargo.toml
+++ b/starkyx/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 hex = "0.4.3"
 subtle-encoding = "0.5.1"
 bincode = "1.3.3"
-curve25519-dalek = "=4.1.0"
+curve25519-dalek = "4.1.0"
 env_logger = "0.9.0"
 
 [dev-dependencies]

--- a/starkyx/src/chip/builder/mod.rs
+++ b/starkyx/src/chip/builder/mod.rs
@@ -314,7 +314,6 @@ pub(crate) mod tests {
     pub use crate::air::parser::AirParser;
     pub use crate::air::RAir;
     pub use crate::chip::instruction::empty::EmptyInstruction;
-    use crate::chip::register::element::ElementRegister;
     pub use crate::chip::register::u16::U16Register;
     pub use crate::chip::register::RegisterSerializable;
     pub use crate::chip::trace::generator::ArithmeticGenerator;

--- a/starkyx/src/chip/ec/edwards/bigint_operations.rs
+++ b/starkyx/src/chip/ec/edwards/bigint_operations.rs
@@ -35,7 +35,7 @@ mod tests {
     use num::BigUint;
     use rand::thread_rng;
 
-    use super::{EdwardsParameters, *};
+    use super::*;
     use crate::chip::ec::edwards::ed25519::params::{Ed25519, Ed25519Parameters};
     use crate::chip::ec::{EllipticCurve, EllipticCurveParameters};
 

--- a/starkyx/src/chip/ec/edwards/ed25519/decompress.rs
+++ b/starkyx/src/chip/ec/edwards/ed25519/decompress.rs
@@ -105,8 +105,6 @@ pub fn decompress(compressed_point: &CompressedEdwardsY) -> (AffinePoint<Ed25519
 mod tests {
     use core::str::FromStr;
 
-    use curve25519_dalek::edwards::CompressedEdwardsY;
-    use num::BigUint;
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -114,7 +112,6 @@ mod tests {
     use crate::chip::ec::edwards::ed25519::gadget::{CompressedPointGadget, CompressedPointWriter};
     use crate::chip::ec::edwards::ed25519::instruction::Ed25519FpInstruction;
     use crate::chip::ec::gadget::{EllipticCurveGadget, EllipticCurveWriter};
-    use crate::chip::ec::point::AffinePoint;
 
     #[derive(Clone, Debug, Copy, Serialize, Deserialize)]
     pub struct Ed25519DecompressTest;

--- a/starkyx/src/chip/ec/scalar.rs
+++ b/starkyx/src/chip/ec/scalar.rs
@@ -173,8 +173,6 @@ mod tests {
 
     use super::*;
     use crate::chip::builder::tests::ArithmeticGenerator;
-    use crate::chip::builder::AirBuilder;
-    use crate::chip::AirParameters;
     use crate::math::goldilocks::cubic::GoldilocksCubicParameters;
     use crate::plonky2::stark::config::PoseidonGoldilocksStarkConfig;
     use crate::plonky2::stark::tests::{test_recursive_starky, test_starky};

--- a/starkyx/src/chip/field/den.rs
+++ b/starkyx/src/chip/field/den.rs
@@ -226,7 +226,6 @@ impl<F: PrimeField64, P: FieldParameters> Instruction<F> for FpDenInstruction<P>
 #[cfg(test)]
 mod tests {
     use num::bigint::RandBigInt;
-    use num::BigUint;
     use rand::thread_rng;
 
     use super::*;

--- a/starkyx/src/chip/field/div.rs
+++ b/starkyx/src/chip/field/div.rs
@@ -181,7 +181,6 @@ impl<F: PrimeField64, P: FieldParameters> Instruction<F> for FpDivInstruction<P>
 #[cfg(test)]
 mod tests {
     use num::bigint::RandBigInt;
-    use num::BigUint;
     use rand::thread_rng;
 
     use super::*;

--- a/starkyx/src/chip/field/mul_const.rs
+++ b/starkyx/src/chip/field/mul_const.rs
@@ -193,7 +193,6 @@ impl<F: PrimeField64, P: FieldParameters> Instruction<F> for FpMulConstInstructi
 #[cfg(test)]
 mod tests {
     use num::bigint::RandBigInt;
-    use num::BigUint;
     use rand::thread_rng;
 
     use super::*;

--- a/starkyx/src/chip/instruction/cycle.rs
+++ b/starkyx/src/chip/instruction/cycle.rs
@@ -262,12 +262,10 @@ impl<F: Field> Instruction<F> for ProcessIdInstruction {
 
 #[cfg(test)]
 mod tests {
-    use plonky2::field::goldilocks_field::GoldilocksField;
 
     use super::*;
     use crate::chip::builder::tests::*;
     use crate::chip::trace::writer::data::AirWriterData;
-    use crate::trace::window_parser::TraceWindowParser;
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
     pub struct CycleTest;

--- a/starkyx/src/chip/mod.rs
+++ b/starkyx/src/chip/mod.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 use self::constraint::Constraint;
 use self::instruction::Instruction;
-use crate::math::extension::cubic::parameters::CubicParameters;
 use crate::math::prelude::*;
 use crate::plonky2::stark::Starky;
 

--- a/starkyx/src/chip/table/accumulator/mod.rs
+++ b/starkyx/src/chip/table/accumulator/mod.rs
@@ -106,10 +106,8 @@ pub mod tests {
     use plonky2::field::types::Sample;
 
     use super::*;
-    use crate::chip::arithmetic::expression::ArithmeticExpression;
     use crate::chip::builder::tests::*;
     use crate::chip::register::element::ElementRegister;
-    use crate::chip::register::Register;
     use crate::math::extension::cubic::element::CubicElement;
     use crate::math::prelude::*;
 

--- a/starkyx/src/chip/table/bus/channel/mod.rs
+++ b/starkyx/src/chip/table/bus/channel/mod.rs
@@ -143,7 +143,6 @@ mod tests {
     use crate::chip::arithmetic::expression::ArithmeticExpression;
     use crate::chip::builder::tests::*;
     use crate::chip::register::Register;
-    use crate::chip::AirParameters;
     use crate::math::extension::cubic::element::CubicElement;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/starkyx/src/chip/table/bus/global/mod.rs
+++ b/starkyx/src/chip/table/bus/global/mod.rs
@@ -127,7 +127,6 @@ mod tests {
     use super::*;
     use crate::chip::builder::tests::*;
     use crate::chip::register::bit::BitRegister;
-    use crate::chip::AirParameters;
     use crate::math::extension::cubic::element::CubicElement;
     use crate::math::prelude::*;
 

--- a/starkyx/src/chip/table/log_derivative/entry.rs
+++ b/starkyx/src/chip/table/log_derivative/entry.rs
@@ -6,7 +6,7 @@ use crate::chip::register::element::ElementRegister;
 use crate::chip::register::{Register, RegisterSerializable};
 use crate::math::prelude::cubic::element::CubicElement;
 use crate::math::prelude::cubic::extension::CubicExtension;
-use crate::math::prelude::{CubicParameters, *};
+use crate::math::prelude::*;
 
 /// A log derivative table entry.
 ///

--- a/starkyx/src/chip/table/lookup/trace.rs
+++ b/starkyx/src/chip/table/lookup/trace.rs
@@ -1,5 +1,3 @@
-use plonky2_maybe_rayon::MaybeIntoParIter;
-
 use super::LogLookupTable;
 use crate::chip::register::array::ArrayRegister;
 use crate::chip::register::cubic::EvalCubic;

--- a/starkyx/src/chip/table/lookup/values/constraint.rs
+++ b/starkyx/src/chip/table/lookup/values/constraint.rs
@@ -12,8 +12,9 @@ use crate::chip::AirParameters;
 use crate::math::prelude::*;
 
 impl<T: EvalCubic, F: Field, E: CubicParameters<F>> LogLookupValues<T, F, E> {
-    pub(crate) fn eval<AP: CubicParser<E>>(&self, parser: &mut AP)
+    pub(crate) fn eval<AP>(&self, parser: &mut AP)
     where
+        AP: CubicParser<E>,
         AP: AirParser<Field = F>,
     {
         let beta = self.challenge.eval(parser);
@@ -27,8 +28,9 @@ impl<T: EvalCubic, F: Field, E: CubicParameters<F>> LogLookupValues<T, F, E> {
         );
     }
 
-    pub(crate) fn eval_global<AP: CubicParser<E>>(&self, parser: &mut AP)
+    pub(crate) fn eval_global<AP>(&self, parser: &mut AP)
     where
+        AP: CubicParser<E>,
         AP: AirParser<Field = F>,
     {
         let beta = self.challenge.eval(parser);

--- a/starkyx/src/chip/table/powers.rs
+++ b/starkyx/src/chip/table/powers.rs
@@ -8,7 +8,7 @@ use crate::chip::register::Register;
 use crate::chip::trace::writer::TraceWriter;
 use crate::math::prelude::*;
 use crate::prelude::cubic::element::CubicElement;
-use crate::prelude::{AirConstraint, AirParameters, CubicParameters};
+use crate::prelude::{AirConstraint, AirParameters};
 
 /// Powers of a challenge element.
 ///

--- a/starkyx/src/chip/uint/bytes/bit_operations/rotate.rs
+++ b/starkyx/src/chip/uint/bytes/bit_operations/rotate.rs
@@ -108,8 +108,6 @@ pub mod tests {
 
     use super::*;
     pub use crate::chip::builder::tests::*;
-    use crate::chip::builder::AirBuilder;
-    use crate::chip::AirParameters;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct RotateTest<const N: usize, const M: usize>;

--- a/starkyx/src/chip/uint/bytes/bit_operations/shift.rs
+++ b/starkyx/src/chip/uint/bytes/bit_operations/shift.rs
@@ -124,9 +124,7 @@ pub mod tests {
 
     use super::*;
     pub use crate::chip::builder::tests::*;
-    use crate::chip::builder::AirBuilder;
     use crate::chip::uint::bytes::bit_operations::util::{bits_u8_to_val, u8_to_bits_le};
-    use crate::chip::AirParameters;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct ShfitTest<const N: usize, const M: usize>;

--- a/starkyx/src/chip/uint/bytes/decode.rs
+++ b/starkyx/src/chip/uint/bytes/decode.rs
@@ -56,8 +56,6 @@ mod tests {
 
     use super::*;
     pub use crate::chip::builder::tests::*;
-    use crate::chip::builder::AirBuilder;
-    use crate::chip::AirParameters;
 
     #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
     struct DecodeTest;

--- a/starkyx/src/chip/uint/bytes/lookup_table/mod.rs
+++ b/starkyx/src/chip/uint/bytes/lookup_table/mod.rs
@@ -165,12 +165,9 @@ mod tests {
 
     use super::*;
     pub use crate::chip::builder::tests::*;
-    use crate::chip::builder::AirBuilder;
     use crate::chip::register::Register;
     use crate::chip::uint::bytes::operations::value::ByteOperation;
     use crate::chip::uint::bytes::register::ByteRegister;
-    use crate::chip::AirParameters;
-    use crate::math::field::Field;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     struct ByteOpTest<const N: usize>;

--- a/starkyx/src/chip/uint/operations/instruction.rs
+++ b/starkyx/src/chip/uint/operations/instruction.rs
@@ -91,7 +91,6 @@ mod tests {
     use crate::chip::register::bit::BitRegister;
     use crate::chip::uint::register::ByteArrayRegister;
     use crate::chip::AirParameters;
-    use crate::math::field::Field;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     struct U32OpTest;

--- a/starkyx/src/chip/uint/register.rs
+++ b/starkyx/src/chip/uint/register.rs
@@ -128,7 +128,6 @@ mod tests {
     use plonky2::field::goldilocks_field::GoldilocksField;
 
     use super::*;
-    use crate::chip::builder::AirBuilder;
     use crate::chip::uint::operations::instruction::UintInstruction;
     use crate::chip::AirParameters;
     use crate::math::goldilocks::cubic::GoldilocksCubicParameters;

--- a/starkyx/src/machine/bytes/stark.rs
+++ b/starkyx/src/machine/bytes/stark.rs
@@ -562,7 +562,7 @@ where
 #[cfg(test)]
 mod tests {
     use plonky2::field::goldilocks_field::GoldilocksField;
-    use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+    use plonky2::iop::witness::PartialWitness;
     use plonky2::plonk::circuit_data::CircuitConfig;
     use rand::Rng;
     use serde::{Deserialize, Serialize};
@@ -571,7 +571,6 @@ mod tests {
     use crate::chip::memory::time::Time;
     use crate::chip::register::element::ElementRegister;
     use crate::chip::register::Register;
-    use crate::chip::trace::writer::InnerWriterData;
     use crate::chip::uint::operations::instruction::UintInstruction;
     use crate::chip::uint::register::U32Register;
     use crate::chip::uint::util::u32_to_le_field_bytes;

--- a/starkyx/src/machine/emulated/stark.rs
+++ b/starkyx/src/machine/emulated/stark.rs
@@ -538,7 +538,7 @@ where
 mod tests {
     use num::bigint::RandBigInt;
     use plonky2::field::goldilocks_field::GoldilocksField;
-    use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+    use plonky2::iop::witness::PartialWitness;
     use plonky2::plonk::circuit_data::CircuitConfig;
     use serde::{Deserialize, Serialize};
 

--- a/starkyx/src/machine/hash/blake/blake2b/builder.rs
+++ b/starkyx/src/machine/hash/blake/blake2b/builder.rs
@@ -49,7 +49,6 @@ pub mod test_utils {
     use crate::chip::uint::util::u64_to_le_field_bytes;
     use crate::chip::AirParameters;
     use crate::machine;
-    use crate::machine::builder::Builder;
     use crate::machine::bytes::builder::BytesBuilder;
     use crate::machine::hash::blake::blake2b::pure::BLAKE2BPure;
     use crate::machine::hash::blake::blake2b::utils::BLAKE2BUtil;

--- a/starkyx/src/machine/stark/mod.rs
+++ b/starkyx/src/machine/stark/mod.rs
@@ -378,7 +378,7 @@ where
 mod tests {
     use num::bigint::RandBigInt;
     use plonky2::field::goldilocks_field::GoldilocksField;
-    use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+    use plonky2::iop::witness::PartialWitness;
     use plonky2::plonk::circuit_data::CircuitConfig;
     use serde::{Deserialize, Serialize};
 

--- a/starkyx/src/math/extension/cubic/extension.rs
+++ b/starkyx/src/math/extension/cubic/extension.rs
@@ -7,7 +7,6 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use super::element::CubicElement;
-use super::parameters::CubicParameters;
 use crate::math::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/starkyx/src/plonky2/cubic/mul_gate.rs
+++ b/starkyx/src/plonky2/cubic/mul_gate.rs
@@ -1,6 +1,4 @@
 use alloc::format;
-use alloc::string::String;
-use alloc::vec::Vec;
 use core::ops::Range;
 
 use plonky2::field::extension::Extendable;

--- a/starkyx/src/plonky2/parser/consumer.rs
+++ b/starkyx/src/plonky2/parser/consumer.rs
@@ -1,5 +1,4 @@
 use alloc::vec;
-use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use plonky2::field::extension::Extendable;

--- a/starkyx/src/plonky2/stark/mod.rs
+++ b/starkyx/src/plonky2/stark/mod.rs
@@ -172,7 +172,7 @@ pub(crate) mod tests {
 
     /// Generate the proof and verify as a stark
     pub(crate) fn test_starky<
-        A: 'static + Debug + Send + Sync,
+        A,
         T,
         F: RichField + Extendable<D>,
         C: CurtaConfig<D, F = F, FE = F::Extension>,
@@ -183,6 +183,7 @@ pub(crate) mod tests {
         trace_generator: &T,
         public_inputs: &[F],
     ) where
+        A: 'static + Debug + Send + Sync,
         A: StarkyAir<F, D>,
         T: TraceGenerator<F, A>,
         T::Error: Into<anyhow::Error>,

--- a/starkyx/src/plonky2/stark/prover.rs
+++ b/starkyx/src/plonky2/stark/prover.rs
@@ -3,7 +3,7 @@
 use core::fmt::Debug;
 use core::iter::once;
 
-use anyhow::{self, ensure, Result};
+use anyhow::{ensure, Result};
 use plonky2::field::extension::Extendable;
 use plonky2::field::packable::Packable;
 use plonky2::field::packed::PackedField;


### PR DESCRIPTION
Remove lock on dalek, pin plonky2 to version 0.2.0 and fix clippy issues.

Dalek was locked because nightly support for `#[stdsimd]` was removed.

NEAR needs `curve25519-dalek` at `4.1.1`, so remove unnecessary lock.

See https://github.com/dalek-cryptography/curve25519-dalek/pull/619
See https://github.com/0xPolygonZero/plonky2/pull/1524
